### PR TITLE
PHP 8.1 compatibility

### DIFF
--- a/controllers/front/validation.php
+++ b/controllers/front/validation.php
@@ -56,8 +56,8 @@ class Ps_WirepaymentValidationModuleFrontController extends ModuleFrontControlle
         $total = (float) $cart->getOrderTotal(true, Cart::BOTH);
         $mailVars = [
             '{bankwire_owner}' => Configuration::get('BANK_WIRE_OWNER'),
-            '{bankwire_details}' => nl2br(Configuration::get('BANK_WIRE_DETAILS')),
-            '{bankwire_address}' => nl2br(Configuration::get('BANK_WIRE_ADDRESS')),
+            '{bankwire_details}' => nl2br(Configuration::get('BANK_WIRE_DETAILS') ?? ''),
+            '{bankwire_address}' => nl2br(Configuration::get('BANK_WIRE_ADDRESS') ?? ''),
         ];
 
         $this->module->validateOrder($cart->id, (int) Configuration::get('PS_OS_BANKWIRE'), $total, $this->module->displayName, null, $mailVars, (int) $currency->id, false, $customer->secure_key);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Since PHP 8.1, `nl2br()` cannot accept `null` as its first argument. This PR aims to give an empty string when the configuration is `null`
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | I really don't think tests are needed here

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
